### PR TITLE
Fix pods setup

### DIFF
--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -177,8 +177,9 @@ class CocoaPods {
   }
 
   /// Ensures the given iOS sub-project of a parent Flutter project
-  /// contains a suitable `Podfile` with Pods added to the Runner target
-  /// and that its `Flutter/Xxx.xcconfig` files include pods configuration.
+  /// contains a suitable `Podfile` and that its `Flutter/Xxx.xcconfig` files
+  /// include pods configuration if there are dependencies
+  /// added to the Runner target.
   void setupPodfile(IosProject iosProject) {
     if (!xcodeProjectInterpreter.isInstalled) {
       // Don't do anything for iOS when host platform doesn't support it.

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -177,8 +177,8 @@ class CocoaPods {
   }
 
   /// Ensures the given iOS sub-project of a parent Flutter project
-  /// contains a suitable `Podfile` and that its `Flutter/Xxx.xcconfig` files
-  /// include pods configuration.
+  /// contains a suitable `Podfile` with Pods added to the Runner target
+  /// and that its `Flutter/Xxx.xcconfig` files include pods configuration.
   void setupPodfile(IosProject iosProject) {
     if (!xcodeProjectInterpreter.isInstalled) {
       // Don't do anything for iOS when host platform doesn't support it.
@@ -210,6 +210,13 @@ class CocoaPods {
   /// Ensures all `Flutter/Xxx.xcconfig` files for the given iOS sub-project of
   /// a parent Flutter project include pods configuration.
   void addPodsDependencyToFlutterXcconfig(IosProject iosProject) {
+    //Don't do anything if the Runner target has no dependencies.
+    final File podfile = iosProject.podfile;
+    final String content = podfile.readAsStringSync();
+    if (!content.contains("target 'Runner' do")) {
+      return;
+    }
+
     _addPodsDependencyToFlutterXcconfig(iosProject, 'Debug');
     _addPodsDependencyToFlutterXcconfig(iosProject, 'Release');
   }

--- a/packages/flutter_tools/lib/src/ios/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/ios/cocoapods.dart
@@ -189,6 +189,7 @@ class CocoaPods {
       return;
     }
     final File podfile = iosProject.podfile;
+
     if (!podfile.existsSync()) {
       final bool isSwift = xcodeProjectInterpreter.getBuildSettings(
         runnerProject.path,
@@ -204,19 +205,19 @@ class CocoaPods {
       ));
       podfileTemplate.copySync(podfile.path);
     }
+
+    final String content = podfile.readAsStringSync();
+    if (!content.contains("target 'Runner' do")) {
+      //Don't do anything if the Runner target has no dependencies.
+      return;
+    }
+
     addPodsDependencyToFlutterXcconfig(iosProject);
   }
 
   /// Ensures all `Flutter/Xxx.xcconfig` files for the given iOS sub-project of
   /// a parent Flutter project include pods configuration.
   void addPodsDependencyToFlutterXcconfig(IosProject iosProject) {
-    //Don't do anything if the Runner target has no dependencies.
-    final File podfile = iosProject.podfile;
-    final String content = podfile.readAsStringSync();
-    if (!content.contains("target 'Runner' do")) {
-      return;
-    }
-
     _addPodsDependencyToFlutterXcconfig(iosProject, 'Debug');
     _addPodsDependencyToFlutterXcconfig(iosProject, 'Release');
   }

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -306,6 +306,11 @@ Future<void> injectPlugins(FlutterProject project) async {
     /// The user may have a custom maintained Podfile that they're running `pod install`
     /// on themselves.
     else if (iosProject.podfile.existsSync() && iosProject.podfileLock.existsSync()) {
+      final String content = iosProject.podfile.readAsStringSync();
+      if (!content.contains("target 'Runner' do")) {
+        /// Don't do anything if the Runner target has no dependencies.
+        return;
+      }
       cocoaPods.addPodsDependencyToFlutterXcconfig(iosProject);
     }
   }

--- a/packages/flutter_tools/test/ios/cocoapods_test.dart
+++ b/packages/flutter_tools/test/ios/cocoapods_test.dart
@@ -30,6 +30,28 @@ void main() {
   CocoaPods cocoaPodsUnderTest;
   InvokeProcess resultOfPodVersion;
 
+  const String contentWithRunnerDependencies = """
+  project 'Runner', {
+    'Debug' => :debug,
+    'Profile' => :release,
+    'Release' => :release,
+  }
+  target 'Runner' do
+    pod 'Flutter'
+  end
+  """;
+
+  const String contentWithoutRunnerDependencies = """
+  project 'Runner', {
+    'Debug' => :debug,
+    'Profile' => :release,
+    'Release' => :release,
+  }
+  target 'OtherTarget' do
+    pod 'SomeDependency'
+  end
+  """;
+
   void pretendPodIsNotInstalled() {
     resultOfPodVersion = () async => throw 'Executable does not exist';
   }
@@ -189,7 +211,7 @@ void main() {
     });
 
     testUsingContext('includes Pod config in xcconfig files, if not present', () async {
-      projectUnderTest.ios.podfile..createSync()..writeAsStringSync('Existing Podfile');
+      projectUnderTest.ios.podfile..createSync()..writeAsStringSync(contentWithRunnerDependencies);
       projectUnderTest.ios.xcodeConfigFor('Debug')
         ..createSync(recursive: true)
         ..writeAsStringSync('Existing debug config');
@@ -215,7 +237,7 @@ void main() {
 
   group('Update xcconfig', () {
     testUsingContext('includes Pod config in xcconfig files, if the user manually added Pod dependencies without using Flutter plugins', () async {
-      projectUnderTest.ios.podfile..createSync()..writeAsStringSync('Custom Podfile');
+      projectUnderTest.ios.podfile..createSync()..writeAsStringSync(contentWithRunnerDependencies);
       projectUnderTest.ios.podfileLock..createSync()..writeAsStringSync('Podfile.lock from user executed `pod install`');
       projectUnderTest.packagesFile..createSync()..writeAsStringSync('');
       projectUnderTest.ios.xcodeConfigFor('Debug')


### PR DESCRIPTION
## Description

This PR adds a check to the Flutter tool Cocoapods integration that prevents adding the Pods include (`#include "Pods/Target Support Files/Pods-Runner/...`) if the project's Podfile does not contain the target `Runner`.

This is useful when attempting to integrate Flutter into an existing application that already has Cocoapods dependencies, but none of them point to the Runner target/project.

I'm facing this problem when integrating Flutter into my existing iOS app which has an `xcworkspace` with multiple projects and a single Podfile to manage all Cocoapods dependencies. None of the dependencies in that Podfile target the `Runner` project.

## Related Issues

I could not find any related issues, but I reckon this is a trivial change and may not be deserving of one.

## Tests

I added the following tests in `packages/flutter_tools/test/ios/cocoapods_test.dart`:

- `does not include Pod config in xcconfig files, if Runner target is not present`

I also changed existing tests in the `cocoapods_test.dart` file to have valid Podfile content instead of just a mock string.