### PR TITLE
Fix iOS launch bundle id

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -342,8 +342,8 @@ class IOSSimulator extends Device {
     // Launch the updated application in the simulator.
     try {
       final IOSApp iosApp = package;
-      final String plistPath = fs.path.join(iosApp.simulatorBundlePath , 'Info.plist');
-      final String bundleIdentifier = getValueFromFile(plistPath, kCFBundleIdentifierKey);
+      final String plistPath = fs.path.join(iosApp.simulatorBundlePath, 'Info.plist');
+      final String bundleIdentifier = iosWorkflow.getPlistValueFromFile(plistPath, kCFBundleIdentifierKey);
 
       await SimControl.instance.launch(id, bundleIdentifier, args);
     } catch (error) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -22,6 +22,7 @@ import '../globals.dart';
 import '../protocol_discovery.dart';
 import 'ios_workflow.dart';
 import 'mac.dart';
+import 'plist_utils.dart';
 
 const String _xcrunPath = '/usr/bin/xcrun';
 
@@ -340,7 +341,11 @@ class IOSSimulator extends Device {
 
     // Launch the updated application in the simulator.
     try {
-      await SimControl.instance.launch(id, package.id, args);
+      final IOSApp iosApp = package;
+      final String plistPath = fs.path.join(iosApp.simulatorBundlePath , 'Info.plist');
+      final String bundleIdentifier = getValueFromFile(plistPath, kCFBundleIdentifierKey);
+
+      await SimControl.instance.launch(id, bundleIdentifier, args);
     } catch (error) {
       printError('$error');
       return LaunchResult.failed();


### PR DESCRIPTION
## Description

This PR changes the flutter tool to use the Bundle Identifier from the compiled app's `Info.plist` instead of reading it from the project file when launching the application on the simulator.

The current implementation of the flutter tool has an issue where it will both fail to expand variables from the `xcconfig` files and, under some circumstances, get the incorrect bundle id from the `pbxproj` when launching the app. See https://github.com/flutter/flutter/issues/31037 for more details.

Before this PR, the flutter tool uses the parsed `package` object's ID to launch the app, which can cause problems.
After this, the tool will use the compiled app's `Info.plist` to launch the app, which should always work.

### Alternatives

An alternative solution to this would be to add 2 more paths to obtain the bundle identifier:
1. Parse the `pbxproj` and find the bundle identifier for the current `BuildMode`
2. If the current identifier is a variable (i.e. of the form `${VAR_NAME}`), expand the VAR_NAME using the appropriate `.xcconfig` file.

This approach seemed more complex than the proposed solution, and since Xcode does these steps already when building the project, it's guaranteed that the resulting `Info.plist` in the built app will have the correct bundle id. It is also required by the operating system, otherwise the app will fail to install.

## Related Issues

Resolves:
- https://github.com/flutter/flutter/issues/31037
- https://github.com/flutter/flutter/issues/22587

## Tests

I added the following tests:

`ios/simulators_test.dart`:
- `startApp uses compiled app's Info.plist to find CFBundleIdentifier`